### PR TITLE
bug: Bridgetown::StaticFile don't have output_ext - so ignoring them

### DIFF
--- a/lib/bridgetown-minify-html/minifier.rb
+++ b/lib/bridgetown-minify-html/minifier.rb
@@ -41,14 +41,14 @@ module BridgetownMinifyHtml
     private
 
     def minify_page(page)
-      return unless compressible?(page.output_ext)
+      return unless compressible?(page)
 
       page.output = compressor.compress(page.output)
       @minified_count += 1
     end
 
-    def compressible?(extension)
-      [".html", ".svg", ".xml"].include?(extension)
+    def compressible?(page)
+      page.respond_to?(:output_ext) && [".html", ".svg", ".xml"].include?(extension)
     end
 
     def compressor


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/325384/88224862-8399a500-cc61-11ea-87b3-c292c88a7610.png)

Stumbled upon this error when working on the Bridgetown website. I thought StaticFile was not included the compression, but this could be the newer build being weird.

Just in case, fixing!