### PR TITLE
Fix: Changelog was pushing to main not master

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Create local changes
       run: |
         gem install github_changelog_generator
-        github_changelog_generator -u ${{ github.context.repo.owner }} -p ${{ github.context.repo.repo }} --token ${{ secrets.GITHUB_TOKEN }} --exclude-labels duplicate,question,invalid,wontfix,nodoc
+        github_changelog_generator -u ${ github.context.repo.owner } -p ${ github.context.repo.repo } --token ${{ secrets.GITHUB_TOKEN }} --exclude-labels duplicate,question,invalid,wontfix,nodoc
     - name: Commit files
       run: |
         git config --local user.email "github-actions@example.com"

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -29,11 +29,7 @@ jobs:
     - name: Create local changes
       run: |
         gem install github_changelog_generator
-
-        echo ${{ github.context.repo.owner }}
-        echo ${{ github.context.repo.repo }}
-
-        github_changelog_generator -u "${{ github.context.repo.owner }}" -p "${{ github.context.repo.repo }}" --token ${{ secrets.GITHUB_TOKEN }} --exclude-labels duplicate,question,invalid,wontfix,nodoc
+        github_changelog_generator -u ${{ github.repository_owner }} -p ${{ github.repository }} --token ${{ secrets.GITHUB_TOKEN }} --exclude-labels duplicate,question,invalid,wontfix,nodoc
     - name: Commit files
       run: |
         git config --local user.email "github-actions@example.com"

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -2,11 +2,12 @@
 name: Changelog
 
 on:
+  workflow_dispatch:
   release:
     types: [created]
   push:
-    branches:
-      - master
+    #branches:
+      #- master
 
 jobs:
   build:
@@ -28,13 +29,17 @@ jobs:
     - name: Create local changes
       run: |
         gem install github_changelog_generator
+
+        echo $GITHUB_REPOSITORY
+
         github_changelog_generator -u bt-rb -p bridgetown-minify-html --token ${{ secrets.GITHUB_TOKEN }} --exclude-labels duplicate,question,invalid,wontfix,nodoc
     - name: Commit files
       run: |
         git config --local user.email "github-actions@example.com"
         git config --local user.name "GitHub Actions"
         git commit -am "[nodoc] Update Changelog" || echo "No changes to commit"
-    - name: Push changes
-      uses: ad-m/github-push-action@master
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+    #- name: Push changes
+      #uses: ad-m/github-push-action@master
+      #with:
+        #github_token: ${{ secrets.GITHUB_TOKEN }}
+        #branch: ${{ github.ref }}

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -19,20 +19,20 @@ jobs:
     - name: Set up Ruby 2.7
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.7.1
+        ruby-version: 2.7.2
     - uses: actions/cache@v2
       with:
         path: vendor/bundle
-        key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
+        key: ${{ runner.os }}-changelog-gem-${{ hashFiles('**/Gemfile.lock') }}
         restore-keys: |
-          ${{ runner.os }}-gem-
+          ${{ runner.os }}-changelog-gem-
     - name: Create local changes
       run: |
         gem install github_changelog_generator
 
-        echo $GITHUB_REPOSITORY
+        IFS=/; GITHUB_REPOSITORY_PARTS=( $(echo $GITHUB_REPOSITORY) )
 
-        github_changelog_generator -u bt-rb -p bridgetown-minify-html --token ${{ secrets.GITHUB_TOKEN }} --exclude-labels duplicate,question,invalid,wontfix,nodoc
+        github_changelog_generator -u $GITHUB_REPOSITORY_PARTS[1] -p $GITHUB_REPOSITORY_PARTS[2] --token ${{ secrets.GITHUB_TOKEN }} --exclude-labels duplicate,question,invalid,wontfix,nodoc
     - name: Commit files
       run: |
         git config --local user.email "github-actions@example.com"

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -6,8 +6,8 @@ on:
   release:
     types: [created]
   push:
-    #branches:
-      #- master
+    branches:
+      - master
 
 jobs:
   build:
@@ -35,8 +35,8 @@ jobs:
         git config --local user.email "github-actions@example.com"
         git config --local user.name "GitHub Actions"
         git commit -am "[nodoc] Update Changelog" || echo "No changes to commit"
-    #- name: Push changes
-      #uses: ad-m/github-push-action@master
-      #with:
-        #github_token: ${{ secrets.GITHUB_TOKEN }}
-        #branch: ${{ github.ref }}
+    - name: Push changes
+      uses: ad-m/github-push-action@master
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        branch: ${{ github.ref }}

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -27,8 +27,6 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-changelog-gem-
     - name: Create local changes
-      with:
-
       run: |
         gem install github_changelog_generator
 

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -29,10 +29,7 @@ jobs:
     - name: Create local changes
       run: |
         gem install github_changelog_generator
-
-        IFS=/; GITHUB_REPOSITORY_PARTS=( $GITHUB_REPOSITORY )
-
-        github_changelog_generator -u $GITHUB_REPOSITORY_PARTS[1] -p $GITHUB_REPOSITORY_PARTS[2] --token ${{ secrets.GITHUB_TOKEN }} --exclude-labels duplicate,question,invalid,wontfix,nodoc
+        github_changelog_generator -u ${{ github.context.repo.owner }} -p ${{ github.context.repo.repo }} --token ${{ secrets.GITHUB_TOKEN }} --exclude-labels duplicate,question,invalid,wontfix,nodoc
     - name: Commit files
       run: |
         git config --local user.email "github-actions@example.com"

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -30,7 +30,7 @@ jobs:
       run: |
         gem install github_changelog_generator
 
-        IFS=/; GITHUB_REPOSITORY_PARTS=( $(echo $GITHUB_REPOSITORY) )
+        IFS=/; GITHUB_REPOSITORY_PARTS=( $GITHUB_REPOSITORY )
 
         github_changelog_generator -u $GITHUB_REPOSITORY_PARTS[1] -p $GITHUB_REPOSITORY_PARTS[2] --token ${{ secrets.GITHUB_TOKEN }} --exclude-labels duplicate,question,invalid,wontfix,nodoc
     - name: Commit files

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Create local changes
       run: |
         gem install github_changelog_generator
-        github_changelog_generator -u ${{ github.repository_owner }} -p ${{ github.repository }} --token ${{ secrets.GITHUB_TOKEN }} --exclude-labels duplicate,question,invalid,wontfix,nodoc
+        github_changelog_generator -u ${{ github.repository_owner }} -p ${{ github.event.repository.name }} --token ${{ secrets.GITHUB_TOKEN }} --exclude-labels duplicate,question,invalid,wontfix,nodoc
     - name: Commit files
       run: |
         git config --local user.email "github-actions@example.com"

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -27,9 +27,15 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-changelog-gem-
     - name: Create local changes
+      with:
+
       run: |
         gem install github_changelog_generator
-        github_changelog_generator -u ${ github.context.repo.owner } -p ${ github.context.repo.repo } --token ${{ secrets.GITHUB_TOKEN }} --exclude-labels duplicate,question,invalid,wontfix,nodoc
+
+        echo ${{ github.context.repo.owner }}
+        echo ${{ github.context.repo.repo }}
+
+        github_changelog_generator -u "${{ github.context.repo.owner }}" -p "${{ github.context.repo.repo }}" --token ${{ secrets.GITHUB_TOKEN }} --exclude-labels duplicate,question,invalid,wontfix,nodoc
     - name: Commit files
       run: |
         git config --local user.email "github-actions@example.com"


### PR DESCRIPTION
The `ad-m/github-push-action` GitHub action made a change which mean it'll push to the `main` branch over `master`. This fixes that by explicitly setting the branch.

**What kind of change does this PR introduce?** (check at least one)

- [X] Bugfix

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [X] All tests are passing
- [ ] New/updated tests are included
