### PR TITLE
Enabling bundler-cache on GitHub Actions

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -20,15 +20,9 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: 3.0
-    - uses: actions/cache@v2
-      with:
-        path: vendor/bundle
-        key: ${{ runner.os }}-changelog-gem-${{ hashFiles('**/Gemfile.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-changelog-gem-
+        bundler-cache: true
     - name: Create local changes
       run: |
-        gem install github_changelog_generator -v "1.15.2"
         github_changelog_generator -u ${{ github.repository_owner }} -p ${{ github.event.repository.name }} --token ${{ secrets.GITHUB_TOKEN }} --exclude-labels duplicate,question,invalid,wontfix,nodoc
     - name: Commit files
       run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,10 +12,11 @@ jobs:
     steps:
       - uses: actions/checkout@master
 
-      - name: Set up Ruby 2.7
+      - name: Set up Ruby 3.0
         uses: actions/setup-ruby@v1
         with:
-          ruby-version: 2.7.x
+          ruby-version: 3.0
+          bundler-cache: true
 
       - name: Publish to RubyGems
         run: |

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -20,18 +20,7 @@ jobs:
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
-    - name: Cache gems
-      uses: actions/cache@v2
-      with:
-        path: vendor/bundle
-        key: ${{ runner.os }}-ruby-${{ matrix.ruby }}-${{ hashFiles('**/Gemfile.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-ruby-${{ matrix.ruby }}
-    - name: Install Gems
-      run: |
-        gem install bundler
-        bundle config path vendor/bundle
-        bundle install --jobs $(nproc) --retry 3
+        bundler-cache: true
     - name: Run tests
       run: |
         bundle exec rake spec

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -11,20 +11,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Ruby 2.7
+    - name: Set up Ruby 3.0
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.7
-    - name: Cache gems
-      uses: actions/cache@v2.1.1
-      with:
-        path: vendor/bundle
-        key: ${{ runner.os }}-rubocop-${{ hashFiles('**/Gemfile.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-rubocop-
-    - name: Install gems
-      run: |
-        bundle config path vendor/bundle
-        bundle install --jobs 4 --retry 3
+        ruby-version: 3.0
+        bundler-cache: true
     - name: Run RuboCop
       run: bundle exec rubocop --parallel

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -14,9 +14,5 @@ jobs:
     steps:
     - name: TypoCheck
       uses: typoci/spellcheck-action@master
-      # with:
-        # A license can be purchased via:
-        # https://gumroad.com/l/MvvBE
-        # typo_ci_license_key: ${{ secrets.TYPO_CI_LICENSE_KEY }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,8 @@ source "https://rubygems.org"
 gemspec
 
 gem "bridgetown", ENV["BRIDGETOWN_VERSION"] if ENV["BRIDGETOWN_VERSION"]
+
+group :development, :test do
+  gem "github_changelog_generator", "~> 1.15.2"
+  gem "rubocop", "~> 0.81.0"
+end


### PR DESCRIPTION
This makes use of the `bundler-cache` option in our GitHub actions, it should mildly speed up the runs but mainly it reduces the amount of code required to maintain.