### PR TITLE
fix: migrate to resource engine

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -9,6 +9,10 @@ on:
     branches: [ main ]
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   test:
     strategy:

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -2,7 +2,7 @@
 name: RSpec
 
 env:
-  BRIDGETOWN_VERSION: 1.0.0.beta2
+  BRIDGETOWN_VERSION: 1.0.0
 
 on:
   push:

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - main
   pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ bundle add bridgetown-minify-html -g bridgetown_plugins
 
 ## Usage
 
-Once you've added the plugin, it'll automatically compress your outputted HTML without any additional configuration required.
+Once you've added the plugin, it'll automatically compress your outputted HTML without any additional configuration required when you run `bin/bridgetown build` or `bin/bridgetown deploy`.
 
 ### Optional configuration options
 

--- a/bridgetown-minify-html.gemspec
+++ b/bridgetown-minify-html.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.7"
 
-  spec.add_dependency "bridgetown", ">= 0.15", "< 2.0"
+  spec.add_dependency "bridgetown", ">= 1.0.0", "< 2.0"
   spec.add_dependency "htmlcompressor", ">= 0.4", "< 1.0"
 
   spec.add_development_dependency "bundler"

--- a/lib/bridgetown-minify-html/minifier.rb
+++ b/lib/bridgetown-minify-html/minifier.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # This actually does the Minification. It gets passed the site object,
-# then it'll just loop through all the pages and documents.
+# then it'll just loop through all the resources.
 module BridgetownMinifyHtml
   class Minifier
     DEFAULT_OPTIONS = {
@@ -31,8 +31,8 @@ module BridgetownMinifyHtml
     end
 
     def call!
-      @site.resources.each do |page|
-        minify_page(page)
+      @site.resources.each do |resource|
+        minify_resource(resource)
       end
 
       Bridgetown.logger.info "Minify HTML:", "Complete, Processed #{@minified_count} file(s)"
@@ -40,16 +40,15 @@ module BridgetownMinifyHtml
 
     private
 
-    def minify_page(page)
-      return unless compressible?(page.destination)
+    def minify_resource(resource)
+      return unless compressible?(resource)
 
-      page.output = compressor.compress(page.output)
+      resource.output = compressor.compress(resource.output)
       @minified_count += 1
     end
 
-    def compressible?(destination)
-      destination.respond_to?(:output_ext) &&
-        [".html", ".svg", ".xml"].include?(destination.output_ext)
+    def compressible?(resource)
+      resource.destination.respond_to?(:output_ext) && [".html", ".svg", ".xml"].include?(resource.destination.output_ext)
     end
 
     def compressor

--- a/lib/bridgetown-minify-html/minifier.rb
+++ b/lib/bridgetown-minify-html/minifier.rb
@@ -48,7 +48,9 @@ module BridgetownMinifyHtml
     end
 
     def compressible?(resource)
-      resource.destination.respond_to?(:output_ext) && [".html", ".svg", ".xml"].include?(resource.destination.output_ext)
+      return unless resource.destination.respond_to?(:output_ext)
+
+      [".html", ".svg", ".xml"].include?(resource.destination.output_ext)
     end
 
     def compressor


### PR DESCRIPTION
Bridgetown v1.0.0 moved to the new resource engine instead of pages and documents. This commit updates the syntax to reflect this change.

EDIT

I somehow did something weird in git and it looked like the changes #25 weren't applied. Now that I have fixed whatever happened, I can see this actually just updates some of the method names and tests which is fine. `¯\_(ツ)_/¯`